### PR TITLE
adds "/campus-addresses/:domain" endpoint

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,4 +14,9 @@
                      [{:queue "partner-works.partner-site.list"
                        :channel partner-http-api.channels/partner-site-list
                        :response true
+                       :timeout 10000}
+
+                      {:queue "partner-works.campus-address.read-by-domain"
+                       :channel partner-http-api.channels/campus-addresses-chan
+                       :response true
                        :timeout 10000}]}}}

--- a/src/partner_http_api/channels.clj
+++ b/src/partner_http_api/channels.clj
@@ -2,7 +2,9 @@
   (:require [clojure.core.async :as async]))
 
 (defonce partner-site-list (async/chan 100))
+(defonce campus-addresses-chan (async/chan 100))
 
 (defn close-all! []
-  (doseq [c [partner-site-list]]
+  (doseq [c [partner-site-list
+             campus-addresses-chan]]
     (async/close! c)))

--- a/src/partner_http_api/service.clj
+++ b/src/partner_http_api/service.clj
@@ -1,17 +1,16 @@
 (ns partner-http-api.service
-  (:require [io.pedestal.http :as bootstrap]
-            [io.pedestal.http.route :as route]
-            [io.pedestal.http.route.definition :refer [defroutes]]
-            [io.pedestal.interceptor :refer [interceptor]]
-            [ring.util.response :as ring-resp]
-            [turbovote.resource-config :refer [config]]
-            [pedestal-toolbox.cors :as cors]
-            [pedestal-toolbox.params :refer :all]
-            [pedestal-toolbox.content-negotiation :refer :all]
-            [clojure.core.async :refer [go alt! timeout]]
-            [bifrost.core :as bifrost]
-            [bifrost.interceptors :as bifrost.i]
-            [partner-http-api.channels :as channels]))
+  (:require
+    [bifrost.core :as bifrost]
+    [bifrost.interceptors :as bifrost.i]
+    [io.pedestal.http :as bootstrap]
+    [io.pedestal.http.route.definition :refer [defroutes]]
+    [io.pedestal.interceptor :refer [interceptor]]
+    [partner-http-api.channels :as channels]
+    [pedestal-toolbox.content-negotiation :refer [negotiate-response-content-type]]
+    [pedestal-toolbox.cors :as cors]
+    [pedestal-toolbox.params :refer [body-params]]
+    [ring.util.response :as ring-resp]
+    [turbovote.resource-config :refer [config]]))
 
 (def ping
   (interceptor
@@ -32,6 +31,11 @@
              (bifrost/interceptor channels/partner-site-list)]}
       ^:interceptors [(bifrost.i/update-in-response [:body :partner-sites]
                                                     [:body] identity)]]
+
+     ["/campus-addresses/:domain"
+      {:get [:campus-addresses
+             (bifrost/interceptor channels/campus-addresses-chan)]}]
+
      ["/ping" {:get [:ping ping]}]]]])
 
 (defn service []


### PR DESCRIPTION
(pointing to "partner-works.campus-address.read-by-domain")

Tracker card:
https://www.pivotaltracker.com/story/show/138818805

Also see:
https://github.com/democracyworks/turbovote-web/pull/202
