### PR TITLE
Add individual partner site endpoint

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -17,7 +17,7 @@
                        :timeout 10000}
 
                       {:queue "partner-works.partner-site.read"
-                       :channel partner-http-api.channels/partner-site
+                       :channel partner-http-api.channels/partner-site-read
                        :response true
                        :timeout 10000}
 

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -16,6 +16,11 @@
                        :response true
                        :timeout 10000}
 
+                      {:queue "partner-works.partner-site.read"
+                       :channel partner-http-api.channels/partner-site
+                       :response true
+                       :timeout 10000}
+
                       {:queue "partner-works.campus-address.read-by-domain"
                        :channel partner-http-api.channels/campus-addresses-chan
                        :response true

--- a/src/partner_http_api/channels.clj
+++ b/src/partner_http_api/channels.clj
@@ -2,10 +2,11 @@
   (:require [clojure.core.async :as async]))
 
 (defonce partner-site-list (async/chan 100))
-(defonce partner-site (async/chan 100))
+(defonce partner-site-read (async/chan 100))
 (defonce campus-addresses-chan (async/chan 100))
 
 (defn close-all! []
   (doseq [c [partner-site-list
+             partner-site-read
              campus-addresses-chan]]
     (async/close! c)))

--- a/src/partner_http_api/channels.clj
+++ b/src/partner_http_api/channels.clj
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async]))
 
 (defonce partner-site-list (async/chan 100))
+(defonce partner-site (async/chan 100))
 (defonce campus-addresses-chan (async/chan 100))
 
 (defn close-all! []

--- a/src/partner_http_api/service.clj
+++ b/src/partner_http_api/service.clj
@@ -35,7 +35,8 @@
        {:get [:partner-site
               (bifrost/interceptor channels/partner-site-read)]}
        ^:interceptors [(bifrost.i/update-in-response [:body :partner-site]
-                                                     [:body] identity)]]]
+                                                     [:body :partner-sites]
+                                                     identity)]]]
 
      ["/campus-addresses/:domain"
       {:get [:campus-addresses

--- a/src/partner_http_api/service.clj
+++ b/src/partner_http_api/service.clj
@@ -30,7 +30,12 @@
       {:get [:partner-site-list
              (bifrost/interceptor channels/partner-site-list)]}
       ^:interceptors [(bifrost.i/update-in-response [:body :partner-sites]
-                                                    [:body] identity)]]
+                                                    [:body] identity)]
+      ["/:domain"
+       {:get [:partner-site
+              (bifrost/interceptor channels/partner-site)]}
+       ^:interceptors [(bifrost.i/update-in-response [:body :partner-site]
+                                                     [:body] identity)]]]
 
      ["/campus-addresses/:domain"
       {:get [:campus-addresses

--- a/src/partner_http_api/service.clj
+++ b/src/partner_http_api/service.clj
@@ -33,7 +33,7 @@
                                                     [:body] identity)]
       ["/:domain"
        {:get [:partner-site
-              (bifrost/interceptor channels/partner-site)]}
+              (bifrost/interceptor channels/partner-site-read)]}
        ^:interceptors [(bifrost.i/update-in-response [:body :partner-site]
                                                      [:body] identity)]]]
 


### PR DESCRIPTION
This change allows us to look up an individual partner and get their election mail strategy

Needed as part of the classic->2.0 user migration work, and specifically [this card](https://www.pivotaltracker.com/story/show/144876025)